### PR TITLE
fix: prevent GC from closing dup'd fd before kernel lookup

### DIFF
--- a/linkcmd/link_cmd.go
+++ b/linkcmd/link_cmd.go
@@ -2,6 +2,7 @@ package linkcmd
 
 import (
 	"net"
+	"runtime"
 	"sync"
 	"syscall"
 
@@ -130,6 +131,8 @@ func CmdAddWithStopCh(
 		},
 	}
 	err = rtnllink.Create(c, ifname, linkinfo)
+	// Keep f reachable until kernel finishes looking up the fd.
+	runtime.KeepAlive(f)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Bug Fix: Prevent GC from closing dup'ed file descriptor before kernel lookup
Root Cause: In CmdAddWithStopCh, the code calls conn2.File() to create an *os.File which owns a dup()'ed file descriptor. This file descriptor is then passed as an integer to the kernel via a Netlink message (rtnllink.Create).

The Go garbage collector (GC) does not track the raw file descriptor once it's extracted via f.Fd(). Because the *os.File variable f is no longer referenced in the code after f.Fd(), the GC might reclaim f and run its finalizer—which closes the file descriptor—before the kernel finishes processing the Netlink message.

As seen in dmesg, this leads to a "Failed to find the socket" error during interface creation, leaving the GTP interface in an inconsistent state and causing a subsequent Kernel NULL pointer dereference (Panic) when adding PDRs.

Solution: Added runtime.KeepAlive(f) after the rtnllink.Create call. This explicitly informs the Go compiler and GC that the reference to f must be maintained until the kernel has successfully finished the sockfd_lookup and increased the socket's reference count.

Summary of dmesg evidence:
[gtp5g] gtp5g_encap_enable: enable gtp5g for the fd(12) type(5)
[gtp5g] gtp5g_encap_enable: Failed to find the socket fd(12)
The log confirms that while the FD number was sent, the socket was already closed by the time the kernel tried to access it. This change ensures the socket remains valid.